### PR TITLE
User Adds Book to Location

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -5,6 +5,7 @@ class BooksController < ApplicationController
 
   def create
     book = Book.new(book_params)
+    book.location = Location.new(location_type: params[:book][:location])
     if book.save
       flash[:success] = "You've added #{book.title} to the store!"
       redirect_to root_path

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,2 +1,4 @@
 class Book < ApplicationRecord
+  has_one :location_slot
+  has_one :location, through: :location_slot
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,4 +1,4 @@
 class Book < ApplicationRecord
-  has_one :location_slot
+  has_one :location_slot, dependent: :destroy
   has_one :location, through: :location_slot
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,0 +1,2 @@
+class Location < ApplicationRecord
+end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,2 +1,4 @@
 class Location < ApplicationRecord
+  has_many :location_slots
+  has_many :books, through: :location_slots
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,4 +1,6 @@
 class Location < ApplicationRecord
   has_many :location_slots
   has_many :books, through: :location_slots
+
+  enum location_type: %w(back table shelf)
 end

--- a/app/models/location_slot.rb
+++ b/app/models/location_slot.rb
@@ -1,0 +1,4 @@
+class LocationSlot < ApplicationRecord
+  belongs_to :book
+  belongs_to :location
+end

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -5,5 +5,6 @@
   <%= f.text_field :author %>
   <%= f.label :title %>
   <%= f.text_field :title %>
+  <%= f.select(:location, Location.location_types.keys.map { |type| [type.titleize, type] }) %>
   <%= f.submit "Add To Store" %>
 <% end %>

--- a/db/migrate/20160828181827_create_locations.rb
+++ b/db/migrate/20160828181827_create_locations.rb
@@ -1,0 +1,10 @@
+class CreateLocations < ActiveRecord::Migration[5.0]
+  def change
+    create_table :locations do |t|
+      t.string :location_type
+      t.integer :location_number
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20160828182015_create_location_slots.rb
+++ b/db/migrate/20160828182015_create_location_slots.rb
@@ -1,0 +1,10 @@
+class CreateLocationSlots < ActiveRecord::Migration[5.0]
+  def change
+    create_table :location_slots do |t|
+      t.references :book, foreign_key: true
+      t.references :location, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20160828182751_change_location_type_column_in_locations.rb
+++ b/db/migrate/20160828182751_change_location_type_column_in_locations.rb
@@ -1,0 +1,9 @@
+class ChangeLocationTypeColumnInLocations < ActiveRecord::Migration[5.0]
+  def up
+    change_column :locations, :location_type, 'integer USING CAST(location_type AS integer)'
+  end
+
+  def down
+    change_column :locations, :location_type, 'string USING CAST(location_type AS string)'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160828181827) do
+ActiveRecord::Schema.define(version: 20160828182015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,15 @@ ActiveRecord::Schema.define(version: 20160828181827) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "location_slots", force: :cascade do |t|
+    t.integer  "book_id"
+    t.integer  "location_id"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.index ["book_id"], name: "index_location_slots_on_book_id", using: :btree
+    t.index ["location_id"], name: "index_location_slots_on_location_id", using: :btree
+  end
+
   create_table "locations", force: :cascade do |t|
     t.string   "location_type"
     t.integer  "location_number"
@@ -29,4 +38,6 @@ ActiveRecord::Schema.define(version: 20160828181827) do
     t.datetime "updated_at",      null: false
   end
 
+  add_foreign_key "location_slots", "books"
+  add_foreign_key "location_slots", "locations"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160828172440) do
+ActiveRecord::Schema.define(version: 20160828181827) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,13 @@ ActiveRecord::Schema.define(version: 20160828172440) do
     t.string   "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "locations", force: :cascade do |t|
+    t.string   "location_type"
+    t.integer  "location_number"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160828182015) do
+ActiveRecord::Schema.define(version: 20160828182751) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 20160828182015) do
   end
 
   create_table "locations", force: :cascade do |t|
-    t.string   "location_type"
+    t.integer  "location_type"
     t.integer  "location_number"
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false

--- a/test/fixtures/location_slots.yml
+++ b/test/fixtures/location_slots.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  book: one
+  location: one
+
+two:
+  book: two
+  location: two

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  location_type: MyString
+  location_number: MyString
+
+two:
+  location_type: MyString
+  location_number: MyString

--- a/test/models/location_slot_test.rb
+++ b/test/models/location_slot_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LocationSlotTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LocationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
A guest can now specify a location (back, table, shelf) when adding a book to the store. 

A "Location" table created to record location types and location number. 

A "Location Slot" table created to join a book with a location.

When a book is added with an associated location type, that location is created along with a location slot connecting the two records.

When a book is destroyed, the associated location slot is destroyed. The location remains.
